### PR TITLE
Add useSampleSWR hook and fetcher utility

### DIFF
--- a/src/hooks/useSampleSWR.ts
+++ b/src/hooks/useSampleSWR.ts
@@ -1,0 +1,19 @@
+import fetcher from '@/libs/fetcher';
+import useSWR from 'swr';
+
+interface Data {
+  useId: number;
+  id: number;
+  title: string;
+  body: string;
+}
+
+const useSampleSWR = () => {
+  const { data }: { data: Data[] } = useSWR('http://jsonplaceholder.typicode.com/posts', fetcher, {
+    suspense: true,
+    fallbackData: [], // SSRではfallback指定がないとerror
+  });
+  console.log(data);
+  return data;
+};
+export default useSampleSWR;

--- a/src/libs/fetcher.ts
+++ b/src/libs/fetcher.ts
@@ -1,0 +1,4 @@
+import axios from 'axios';
+
+const fetcher = (url: string) => axios.get(url).then(res => res.data);
+export default fetcher;


### PR DESCRIPTION
This pull request adds a new hook called useSampleSWR and a utility function called fetcher. The useSampleSWR hook is used to fetch data from an API endpoint using the SWR library. The fetcher utility function is a helper function that uses Axios to make the actual API request. These additions will be useful for handling data fetching in our application.